### PR TITLE
support ParseError in Diagnostics

### DIFF
--- a/gopls/internal/lsp/cache/check.go
+++ b/gopls/internal/lsp/cache/check.go
@@ -1417,6 +1417,15 @@ func localPackageKey(inputs typeCheckInputs) source.Hash {
 	for _, fh := range inputs.goFiles {
 		fmt.Fprintln(hasher, fh.FileIdentity())
 	}
+	// goxls: include gop files while calculating package key
+	fmt.Fprintf(hasher, "compiledGopFiles: %d\n", len(inputs.compiledGopFiles))
+	for _, fh := range inputs.compiledGopFiles {
+		fmt.Fprintln(hasher, fh.FileIdentity())
+	}
+	fmt.Fprintf(hasher, "gopFiles: %d\n", len(inputs.gopFiles))
+	for _, fh := range inputs.gopFiles {
+		fmt.Fprintln(hasher, fh.FileIdentity())
+	}
 
 	// types sizes
 	sz := inputs.sizes.(*types.StdSizes)

--- a/gopls/internal/lsp/cache/snapshot.go
+++ b/gopls/internal/lsp/cache/snapshot.go
@@ -17,6 +17,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -31,6 +32,7 @@ import (
 	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/go/types/objectpath"
 	"golang.org/x/tools/gopls/internal/bug"
+	"golang.org/x/tools/gopls/internal/goxls/goputil"
 	"golang.org/x/tools/gopls/internal/lsp/command"
 	"golang.org/x/tools/gopls/internal/lsp/filecache"
 	"golang.org/x/tools/gopls/internal/lsp/protocol"
@@ -2037,7 +2039,8 @@ func (s *snapshot) clone(ctx, bgCtx context.Context, changes map[span.URI]*fileC
 		// because the file type that matters is not what the *client* tells us,
 		// but what the Go command sees.
 		var invalidateMetadata, pkgFileChanged, importDeleted bool
-		if strings.HasSuffix(uri.Filename(), ".go") {
+		if strings.HasSuffix(uri.Filename(), ".go") ||
+			goputil.FileKind(path.Ext(uri.Filename())) != goputil.FileUnknown { // goxls: Support Go+
 			invalidateMetadata, pkgFileChanged, importDeleted = metadataChanges(ctx, s, originalFH, change.fileHandle)
 		}
 

--- a/gopls/internal/lsp/source/util.go
+++ b/gopls/internal/lsp/source/util.go
@@ -101,6 +101,8 @@ func FileKindForLang(langID string) FileKind {
 		return Tmpl
 	case "go.work":
 		return Work
+	case "gop": // goxls: Support Go+
+		return Gop
 	default:
 		return UnknownKind
 	}


### PR DESCRIPTION
支持 Diagnostics 提示 ParseError（syntax）

![image](https://github.com/goplus/tools/assets/1492263/f53ad748-c631-46c7-9292-71ef59ff9c5b)

P.S. 已知问题：某些特殊的语法错误会导致问题，如

![image](https://github.com/goplus/tools/assets/1492263/76e6db84-69d1-4eab-b08a-d3dc44161410)

（这里结尾多了一个 `}`）会导致 language server 无法得到 diagnostics 结果，且内存暴增