### PR TITLE
Ignore gop_autogen files for diagnostics

### DIFF
--- a/gopls/internal/lsp/diagnostics.go
+++ b/gopls/internal/lsp/diagnostics.go
@@ -482,6 +482,9 @@ func (s *Server) diagnosePkgs(ctx context.Context, snapshot source.Snapshot, toD
 			bug.Reportf("go/analysis reported diagnostics for the builtin file: %v", adiags)
 			continue
 		}
+		if fname := filepath.Base(uri.Filename()); strings.HasPrefix(fname, "gop_autogen") { // goxls: Ignore gop_autogen files
+			continue
+		}
 		tdiags := pkgDiags[uri]
 		var tdiags2, adiags2 []*source.Diagnostic
 		source.CombineDiagnostics(tdiags, adiags, &tdiags2, &adiags2)
@@ -511,6 +514,9 @@ func (s *Server) diagnosePkgs(ctx context.Context, snapshot source.Snapshot, toD
 		// Don't report distracting errors
 		if snapshot.IsBuiltin(uri) {
 			bug.Reportf("type checking reported diagnostics for the builtin file: %v", diags)
+			continue
+		}
+		if fname := filepath.Base(uri.Filename()); strings.HasPrefix(fname, "gop_autogen") { // goxls: Ignore gop_autogen files
 			continue
 		}
 		s.storeDiagnostics(snapshot, uri, typeCheckSource, diags, true)

--- a/gopls/internal/lsp/diagnostics.go
+++ b/gopls/internal/lsp/diagnostics.go
@@ -504,6 +504,10 @@ func (s *Server) diagnosePkgs(ctx context.Context, snapshot source.Snapshot, toD
 			s.storeDiagnostics(snapshot, uri, typeCheckSource, pkgDiags[uri], true)
 			storedPkgDiags[uri] = true
 		}
+		for _, uri := range m.CompiledGopFiles { // goxls: Incldue gop files
+			s.storeDiagnostics(snapshot, uri, typeCheckSource, pkgDiags[uri], true)
+			storedPkgDiags[uri] = true
+		}
 	}
 	// Store the package diagnostics.
 	for uri, diags := range pkgDiags {

--- a/gopls/internal/lsp/diagnostics_gox.go
+++ b/gopls/internal/lsp/diagnostics_gox.go
@@ -1,0 +1,5 @@
+// Copyright 2023 The GoPlus Authors (goplus.org). All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package lsp


### PR DESCRIPTION
* Ignore gop_autogen files for diagnostics
* Guarantee to store type-checking diagnostics for every compiled gop file