### PR TITLE
update:support gox test codelens

### DIFF
--- a/gopls/internal/lsp/source/code_lens_gox.go
+++ b/gopls/internal/lsp/source/code_lens_gox.go
@@ -182,7 +182,7 @@ func gopToggleDetailsCodeLens(ctx context.Context, snapshot Snapshot, fh FileHan
 
 func gopCommandCodeLens(ctx context.Context, snapshot Snapshot, fh FileHandle) ([]protocol.CodeLens, error) {
 	filename := fh.URI().Filename()
-	if strings.HasSuffix(filename, "_test.go") || strings.HasSuffix(filename, "_test.gop") {
+	if strings.HasSuffix(filename, "_test.go") || strings.HasSuffix(filename, "_test.gop") || strings.HasSuffix(filename, "test.gox") {
 		return nil, nil
 	}
 	pgf, err := snapshot.ParseGop(ctx, fh, parser.PackageClauseOnly)

--- a/gopls/internal/lsp/source/code_lens_gox.go
+++ b/gopls/internal/lsp/source/code_lens_gox.go
@@ -215,6 +215,15 @@ func goxTestCodeLens(pgf *ParsedGopFile, classType string) ([]protocol.CodeLens,
 	if err != nil {
 		return nil, err
 	}
+	codelens := []protocol.CodeLens{
+		{Range: rng, Command: &protocol.Command{
+			Title:   "run test package",
+			Command: "gop.test.package",
+		}},
+	}
+	if pgf.File.IsProj && classType == "main" { //goxls:proj gox test
+		return codelens, nil
+	}
 	args, err := command.MarshalArgs(
 		map[string]string{
 			"functionName": "Test_" + classType,
@@ -223,16 +232,13 @@ func goxTestCodeLens(pgf *ParsedGopFile, classType string) ([]protocol.CodeLens,
 	if err != nil {
 		return nil, err
 	}
-	codelens := []protocol.CodeLens{
-		{Range: rng, Command: &protocol.Command{
-			Title:   "run test package",
-			Command: "gop.test.package",
-		}},
-		{Range: rng, Command: &protocol.Command{ // goxls: add test cursor as test file
+	codelens = append(codelens, protocol.CodeLens{
+		Range: rng,
+		Command: &protocol.Command{
 			Title:     "run file tests",
 			Command:   "gop.test.cursor",
 			Arguments: args,
-		}},
-	}
+		},
+	})
 	return codelens, nil
 }

--- a/gopls/internal/lsp/source/symbols_gox.go
+++ b/gopls/internal/lsp/source/symbols_gox.go
@@ -25,7 +25,7 @@ func GopDocumentSymbols(ctx context.Context, snapshot Snapshot, fh FileHandle) (
 		return nil, fmt.Errorf("getting file for GopDocumentSymbols: %w", err)
 	}
 	file := pgf.File
-	classType, _ := parserutil.GetClassType(file, fh.URI().Filename())
+	classType, isTest := parserutil.GetClassType(file, fh.URI().Filename())
 	// Build symbols for file declarations. When encountering a declaration with
 	// errors (typically because positions are invalid), we skip the declaration
 	// entirely. VS Code fails to show any symbols if one of the top-level
@@ -49,6 +49,9 @@ func GopDocumentSymbols(ctx context.Context, snapshot Snapshot, fh FileHandle) (
 						} else {
 							name = "Main"
 						}
+					}
+					if decl.Shadow && name == "Main" && isTest {
+						name = "TestMain" //test gox file
 					}
 					if !decl.IsClass && decl.Recv != nil && len(decl.Recv.List) > 0 {
 						fs.Name = fmt.Sprintf("(%s).%s", typesutil.ExprString(decl.Recv.List[0].Type), fs.Name)

--- a/gopls/internal/lsp/source/symbols_gox.go
+++ b/gopls/internal/lsp/source/symbols_gox.go
@@ -25,7 +25,7 @@ func GopDocumentSymbols(ctx context.Context, snapshot Snapshot, fh FileHandle) (
 		return nil, fmt.Errorf("getting file for GopDocumentSymbols: %w", err)
 	}
 	file := pgf.File
-	classType, isTest := parserutil.GetClassType(file, fh.URI().Filename())
+	classType, _ := parserutil.GetClassType(file, fh.URI().Filename())
 	// Build symbols for file declarations. When encountering a declaration with
 	// errors (typically because positions are invalid), we skip the declaration
 	// entirely. VS Code fails to show any symbols if one of the top-level
@@ -49,9 +49,6 @@ func GopDocumentSymbols(ctx context.Context, snapshot Snapshot, fh FileHandle) (
 						} else {
 							name = "Main"
 						}
-					}
-					if decl.Shadow && name == "Main" && isTest {
-						name = "TestMain" //test gox file
 					}
 					if !decl.IsClass && decl.Recv != nil && len(decl.Recv.List) > 0 {
 						fs.Name = fmt.Sprintf("(%s).%s", typesutil.ExprString(decl.Recv.List[0].Type), fs.Name)

--- a/gopls/internal/lsp/source/util_gox.go
+++ b/gopls/internal/lsp/source/util_gox.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/goplus/gop/ast"
+	"github.com/goplus/gop/cl"
 	"github.com/goplus/gop/printer"
 	"github.com/goplus/gop/token"
 	"github.com/goplus/gop/x/typesutil"
@@ -286,4 +287,17 @@ func gopEmbeddedIdent(x ast.Expr) *ast.Ident {
 		}
 	}
 	return nil
+}
+
+func GoxTestClassType(file *ast.File, filename string) (classType string, isGoxTest bool) {
+	if file.IsClass {
+		var ext string
+		classType, _, ext = cl.ClassNameAndExt(filename)
+		if file.IsNormalGox {
+			isGoxTest = strings.HasSuffix(ext, "_test.gox")
+		} else {
+			isGoxTest = strings.HasSuffix(ext, "test.gox")
+		}
+	}
+	return
 }

--- a/gopls/internal/lsp/source/util_gox_test.go
+++ b/gopls/internal/lsp/source/util_gox_test.go
@@ -1,0 +1,59 @@
+package source
+
+import (
+	"github.com/goplus/gop/ast"
+
+	"testing"
+)
+
+func TestGoxTestClassType(t *testing.T) {
+	type testData struct {
+		isClass     bool
+		isNormalGox bool
+		isProj      bool
+		fileName    string
+		classType   string
+		isGoxTest   bool
+	}
+	tests :=
+		[]*testData{
+			{false, false, false, "abc.gop", "", false},
+			{false, false, false, "abc_test.gop", "", false},
+
+			{true, true, false, "abc.gox", "abc", false},
+			{true, true, false, "Abc.gox", "Abc", false},
+			{true, true, false, "abc_demo.gox", "abc", false},
+			{true, true, false, "Abc_demo.gox", "Abc", false},
+
+			{true, false, false, "get.yap", "get", false},
+			{true, false, false, "get_p_#id.yap", "get_p_id", false},
+			{true, false, true, "main.yap", "main", false},
+
+			{true, true, false, "main.gox", "main", false},
+			{true, true, false, "main_demo.gox", "main", false},
+			{true, true, false, "abc_xtest.gox", "abc", false},
+			{true, true, false, "main_xtest.gox", "main", false},
+
+			{true, true, false, "abc_test.gox", "abc", true},
+			{true, true, false, "Abc_test.gox", "Abc", true},
+			{true, true, false, "main_test.gox", "main", true},
+
+			{true, false, false, "abc_yap.gox", "abc", false},
+			{true, false, false, "Abc_yap.gox", "Abc", false},
+			{true, false, true, "main_yap.gox", "main", false},
+
+			{true, false, false, "abc_ytest.gox", "abc", true},
+			{true, false, false, "Abc_ytest.gox", "Abc", true},
+			{true, false, true, "main_ytest.gox", "main", true},
+		}
+	for _, test := range tests {
+		f := &ast.File{IsClass: test.isClass, IsNormalGox: test.isNormalGox, IsProj: test.isProj}
+		classType, isGoxTest := GoxTestClassType(f, test.fileName)
+		if isGoxTest != test.isGoxTest {
+			t.Fatalf("%v check classType isTest want %v, got %v.", test.fileName, test.isGoxTest, isGoxTest)
+		}
+		if classType != test.classType {
+			t.Fatalf("%v getClassType want %v, got %v.", test.fileName, test.classType, classType)
+		}
+	}
+}


### PR DESCRIPTION
Now  can directly click on the run file tests and run test package codelens on test.gox to execute the corresponding tests
![image](https://github.com/goplus/tools/assets/51194195/ae08111c-65a8-48f3-84e6-7e9fa9a9dabe)
![image](https://github.com/goplus/tools/assets/51194195/02e5675d-a9b5-4455-8ed6-509f6918b1e1)



For a classfile with a get2_ytest.gox test, executing file test on that file is actually executing the test function corresponding to that file, so when codelens returns run file test, it is actually calling the test function that is unique to that test file

- [x] In order for gop test to perform function tests for gox, the vscode plugin has also been modified https://github.com/goplus/vscode-gop/pull/63
