### PR TITLE
fix:correct anonymous overloaded function definition location

### DIFF
--- a/gopls/internal/lsp/source/definition_gox.go
+++ b/gopls/internal/lsp/source/definition_gox.go
@@ -80,15 +80,14 @@ func GopDefinition(ctx context.Context, snapshot Snapshot, fh FileHandle, positi
 
 	// The general case: the cursor is on an identifier.
 	_, obj, _ := gopReferencedObject(pkg, pgf, pos)
-
 	if obj == nil {
 		return nil, nil
 	}
 
 	anonyOvId := false
 	if fun, ok := obj.(*types.Func); ok {
-		for _, ov := range pkg.GopTypesInfo().Implicits {
-			if v, ok := ov.(*types.Func); ok {
+		for ov := range pkg.GopTypesInfo().Implicits {
+			if v, ok := ov.(*ast.FuncLit); ok {
 				if v.Pos() == fun.Pos() {
 					anonyOvId = true
 					break

--- a/gopls/internal/lsp/source/definition_gox.go
+++ b/gopls/internal/lsp/source/definition_gox.go
@@ -84,12 +84,12 @@ func GopDefinition(ctx context.Context, snapshot Snapshot, fh FileHandle, positi
 		return nil, nil
 	}
 
-	anonyOvId := false
+	var anonyOvFunc *ast.FuncLit
 	if fun, ok := obj.(*types.Func); ok {
 		for ov := range pkg.GopTypesInfo().Implicits {
 			if v, ok := ov.(*ast.FuncLit); ok {
 				if v.Pos() == fun.Pos() {
-					anonyOvId = true
+					anonyOvFunc = v
 					break
 				}
 			}
@@ -149,9 +149,8 @@ func GopDefinition(ctx context.Context, snapshot Snapshot, fh FileHandle, positi
 	}
 
 	typeEnd := adjustedObjEnd(obj)
-	if anonyOvId {
-		// goxls: anonymous overload function identifier range
-		typeEnd = obj.Pos() + token.Pos(len("func"))
+	if anonyOvFunc != nil { // goxls: anonymous overload function
+		typeEnd = anonyOvFunc.Type.End()
 	}
 	// Finally, map the object position.
 	loc, err := mapPosition(ctx, pkg.FileSet(), snapshot, obj.Pos(), typeEnd)

--- a/gopls/internal/lsp/source/definition_gox.go
+++ b/gopls/internal/lsp/source/definition_gox.go
@@ -338,9 +338,9 @@ func IsOverloadAnonymousMember(ctx context.Context, snapshot Snapshot, pkg Packa
 			if err != nil {
 				return nil, nil, nil, false
 			}
-			varPkg := pkgs[0]
-			if funcLit, ovObj, ok := inPkg(varPkg); ok {
-				return varPkg, funcLit, ovObj, true
+			localPkg := pkgs[0]
+			if funcLit, ovObj, ok := inPkg(localPkg); ok {
+				return localPkg, funcLit, ovObj, true
 			}
 		}
 	}

--- a/gopls/internal/lsp/source/definition_gox.go
+++ b/gopls/internal/lsp/source/definition_gox.go
@@ -147,7 +147,9 @@ func GopDefinition(ctx context.Context, snapshot Snapshot, fh FileHandle, positi
 	}
 
 	typeEnd := adjustedObjEnd(obj)
-	if anonyOvFunc != nil { // goxls: anonymous overload function
+	if anonyOvFunc != nil {
+		// goxls:if the object is an anonymous overload function
+		// use the end of the overload function
 		typeEnd = anonyOvFunc.Type.End()
 	}
 	// Finally, map the object position.
@@ -325,18 +327,18 @@ func IsOverloadAnonymousMember(ctx context.Context, snapshot Snapshot, pkg Packa
 		return pkg, funcLit, ovObj, true
 	}
 
-	// goxls:match in variants package
+	// goxls:match in local package
 	if strings.HasSuffix(string(declURI), ".gop") {
-		variants, err := snapshot.MetadataForFile(ctx, declURI)
+		metas, err := snapshot.MetadataForFile(ctx, declURI)
 		if err != nil {
 			return nil, nil, nil, false
 		}
-		for _, m := range variants {
-			varPkgs, err := snapshot.TypeCheck(ctx, m.ID)
+		for _, m := range metas {
+			pkgs, err := snapshot.TypeCheck(ctx, m.ID)
 			if err != nil {
 				return nil, nil, nil, false
 			}
-			varPkg := varPkgs[0]
+			varPkg := pkgs[0]
 			if funcLit, ovObj, ok := inPkg(varPkg); ok {
 				return varPkg, funcLit, ovObj, true
 			}

--- a/gopls/internal/regtest/misc/definition_gox_test.go
+++ b/gopls/internal/regtest/misc/definition_gox_test.go
@@ -1,0 +1,150 @@
+package misc
+
+import (
+	"testing"
+
+	. "golang.org/x/tools/gopls/internal/lsp/regtest"
+)
+
+const overloadDefinition1 = `
+-- go.mod --
+module mod.com
+
+go 1.21.4
+-- def.gop --
+func add = (
+	func(a, b int) int {
+ 		return a + b
+   	}
+   	func(a, b string) string {
+   		return a + b
+   	}
+)
+-- test.gop --
+println add(100, 7)
+`
+
+func TestOverloadDefinition1(t *testing.T) {
+	Run(t, overloadDefinition1, func(t *testing.T, env *Env) {
+		env.OpenFile("test.gop")
+		loc := env.GoToDefinition(env.RegexpSearch("test.gop", "add"))
+		name := env.Sandbox.Workdir.URIToPath(loc.URI)
+		if want := "def.gop"; name != want {
+			t.Errorf("GoToDefinition: got file %q, want %q", name, want)
+		}
+		// goxls : match the 'func' position of the corresponding overloaded function
+		if want := env.RegexpSearch("def.gop", `(func)\(a, b int\) int`); loc != want {
+			t.Errorf("GoToDefinition: got location %v, want %v", loc, want)
+		}
+	})
+}
+
+const overloadDefinition2 = `
+-- go.mod --
+module mod.com
+
+go 1.21.4
+-- def.gop --
+func mulInt(a, b int) int {
+	return a * b
+}
+
+func mulFloat(a, b float64) float64 {
+	return a * b
+}
+
+func mul = (
+	mulInt
+	mulFloat
+)
+-- test.gop --
+println mul(100, 7)
+`
+
+func TestOverloadDefinition2(t *testing.T) {
+	Run(t, overloadDefinition2, func(t *testing.T, env *Env) {
+		env.OpenFile("test.gop")
+		loc := env.GoToDefinition(env.RegexpSearch("test.gop", `println (mul)\(100, 7\)`))
+		name := env.Sandbox.Workdir.URIToPath(loc.URI)
+		if want := "def.gop"; name != want {
+			t.Errorf("GoToDefinition: got file %q, want %q", name, want)
+		}
+		// goxls: match mulInt
+		if want := env.RegexpSearch("def.gop", `func (mulInt)\(a, b int\) int`); loc != want {
+			t.Errorf("GoToDefinition: got location %v, want %v", loc, want)
+		}
+	})
+}
+
+const overloadDefinition3 = `
+-- go.mod --
+module mod.com
+
+go 1.21.4
+-- def.gop --
+type foo struct {
+}
+
+func (a *foo) mulInt(b int) *foo {
+	return a
+}
+
+func (a *foo) mulFoo(b *foo) *foo {
+	return a
+}
+
+func (foo).mul = (
+	(foo).mulInt
+	(foo).mulFoo
+)
+-- test.gop --
+var a *foo
+var c = a.mul(100)
+`
+
+func TestOverloadDefinition3(t *testing.T) {
+	Run(t, overloadDefinition3, func(t *testing.T, env *Env) {
+		env.OpenFile("test.gop")
+		loc := env.GoToDefinition(env.RegexpSearch("test.gop", "mul"))
+		name := env.Sandbox.Workdir.URIToPath(loc.URI)
+		if want := "def.gop"; name != want {
+			t.Errorf("GoToDefinition: got file %q, want %q", name, want)
+		}
+		// goxls: match mulInt
+		if want := env.RegexpSearch("def.gop", `func \(a \*foo\) (mulInt)\(b int\) \*foo`); loc != want {
+			t.Errorf("GoToDefinition: got location %v, want %v", loc, want)
+		}
+	})
+}
+
+const overloadDefinition4 = `
+-- go.mod --
+module mod.com
+
+go 1.21.4
+-- def.go --
+package main
+type foo struct {
+}
+
+func (f *foo) Broadcast__0(msg string) bool {
+	return true
+}
+-- test.gop --
+var a *foo
+a.Broadcast("hhh")
+`
+
+func TestOverloadDefinition4(t *testing.T) {
+	Run(t, overloadDefinition4, func(t *testing.T, env *Env) {
+		env.OpenFile("test.gop")
+		loc := env.GoToDefinition(env.RegexpSearch("test.gop", "Broadcast"))
+		name := env.Sandbox.Workdir.URIToPath(loc.URI)
+		if want := "def.go"; name != want {
+			t.Errorf("GoToDefinition: got file %q, want %q", name, want)
+		}
+		if want := env.RegexpSearch("def.go", `Broadcast__0`); loc != want {
+			t.Errorf("GoToDefinition: got location %v, want %v", loc, want)
+		}
+	})
+}

--- a/gopls/internal/regtest/misc/definition_gox_test.go
+++ b/gopls/internal/regtest/misc/definition_gox_test.go
@@ -33,7 +33,7 @@ func TestOverloadDefinition1(t *testing.T) {
 			t.Errorf("GoToDefinition: got file %q, want %q", name, want)
 		}
 		// goxls : match the 'func' position of the corresponding overloaded function
-		if want := env.RegexpSearch("def.gop", `(func)\(a, b int\) int`); loc != want {
+		if want := env.RegexpSearch("def.gop", `func\(a, b int\) int`); loc != want {
 			t.Errorf("GoToDefinition: got location %v, want %v", loc, want)
 		}
 	})

--- a/gopls/internal/regtest/misc/definition_gox_test.go
+++ b/gopls/internal/regtest/misc/definition_gox_test.go
@@ -6,7 +6,7 @@ import (
 	. "golang.org/x/tools/gopls/internal/lsp/regtest"
 )
 
-const overloadDefinition1 = `
+const anonyOverload = `
 -- go.mod --
 module mod.com
 
@@ -39,22 +39,14 @@ func main() {
 }
 `
 
-func TestOverloadDefinition1(t *testing.T) {
-	Run(t, overloadDefinition1, func(t *testing.T, env *Env) {
-		env.OpenFile("test.gop")
-		loc := env.GoToDefinition(env.RegexpSearch("test.gop", "add"))
-		name := env.Sandbox.Workdir.URIToPath(loc.URI)
-		if want := "def.gop"; name != want {
-			t.Errorf("GoToDefinition: got file %q, want %q", name, want)
-		}
-		// goxls : match the 'func' position of the corresponding overloaded function
-		if want := env.RegexpSearch("def.gop", `func\(a, b int\) int`); loc != want {
-			t.Errorf("GoToDefinition: got location %v, want %v", loc, want)
-		}
-	})
+func TestAnonyOverload(t *testing.T) {
+	testCases := []match{
+		{`test.gop`, `println (add)\(100, 7\)`, "def.gop", `func\(a, b int\) int`},
+	}
+	runGoToDefinitionTest(t, anonyOverload, testCases)
 }
 
-const overloadDefinition2 = `
+const overloadMixAnonyAndNamed = `
 -- go.mod --
 module mod.com
 
@@ -98,22 +90,14 @@ func main() {
 }
 `
 
-func TestOverloadDefinition2(t *testing.T) {
-	Run(t, overloadDefinition2, func(t *testing.T, env *Env) {
-		env.OpenFile("test.gop")
-		loc := env.GoToDefinition(env.RegexpSearch("test.gop", `println (mul)\(100, 7\)`))
-		name := env.Sandbox.Workdir.URIToPath(loc.URI)
-		if want := "def.gop"; name != want {
-			t.Errorf("GoToDefinition: got file %q, want %q", name, want)
-		}
-		// goxls: match mulInt
-		if want := env.RegexpSearch("def.gop", `func (mulInt)\(a, b int\) int`); loc != want {
-			t.Errorf("GoToDefinition: got location %v, want %v", loc, want)
-		}
-	})
+func TestOverloadMixAnonyAndNamed(t *testing.T) {
+	testCases := []match{
+		{`test.gop`, `println (mul)\(100, 7\)`, "def.gop", `func (mulInt)\(a, b int\) int`},
+	}
+	runGoToDefinitionTest(t, overloadMixAnonyAndNamed, testCases)
 }
 
-const overloadDefinition3 = `
+const overloadMethod = `
 -- go.mod --
 module mod.com
 
@@ -160,22 +144,14 @@ func main() {
 }
 `
 
-func TestOverloadDefinition3(t *testing.T) {
-	Run(t, overloadDefinition3, func(t *testing.T, env *Env) {
-		env.OpenFile("test.gop")
-		loc := env.GoToDefinition(env.RegexpSearch("test.gop", "mul"))
-		name := env.Sandbox.Workdir.URIToPath(loc.URI)
-		if want := "def.gop"; name != want {
-			t.Errorf("GoToDefinition: got file %q, want %q", name, want)
-		}
-		// goxls: match mulInt
-		if want := env.RegexpSearch("def.gop", `func \(a \*foo\) (mulInt)\(b int\) \*foo`); loc != want {
-			t.Errorf("GoToDefinition: got location %v, want %v", loc, want)
-		}
-	})
+func TestOverloadMethod(t *testing.T) {
+	testCases := []match{
+		{`test.gop`, `var c = a.(mul)\(100\)`, "def.gop", `func \(a \*foo\) (mulInt)\(b int\) \*foo`},
+	}
+	runGoToDefinitionTest(t, overloadMethod, testCases)
 }
 
-const overloadDefinition4 = `
+const overloadFromGo = `
 -- go.mod --
 module mod.com
 
@@ -219,16 +195,93 @@ func main() {
 }
 `
 
-func TestOverloadDefinition4(t *testing.T) {
-	Run(t, overloadDefinition4, func(t *testing.T, env *Env) {
-		env.OpenFile("test.gop")
-		loc := env.GoToDefinition(env.RegexpSearch("test.gop", "onKey"))
-		name := env.Sandbox.Workdir.URIToPath(loc.URI)
-		if want := "def.go"; name != want {
-			t.Errorf("GoToDefinition: got file %q, want %q", name, want)
-		}
-		if want := env.RegexpSearch("def.go", `OnKey__0`); loc != want {
-			t.Errorf("GoToDefinition: got location %v, want %v", loc, want)
+func TestOverloadFromGo(t *testing.T) {
+	testCases := []match{
+		{`test.gop`, `onKey`, "def.go", `OnKey__0`},
+	}
+	runGoToDefinitionTest(t, overloadFromGo, testCases)
+}
+
+const overloadCrossPkg = `
+-- go.mod --
+module mod.com
+
+go 1.19
+-- lib/lib.gop --
+package lib
+
+func Add = (
+	func(a, b int) int {
+		return a + b
+	}
+	func(a, b string) string {
+		return a + b
+	}
+)
+
+-- lib/gop_autogen.go --
+package lib
+
+const GopPackage = true
+const _ = true
+func Add__0(a int, b int) int {
+	return a + b
+}
+func Add__1(a string, b string) string {
+	return a + b
+}
+
+-- main.gop --
+import (
+	"mod.com/lib"
+)
+
+println lib.Add(100, 7)
+println lib.Add("Hello", "World")
+
+-- gop_autogen.go --
+package main
+
+import (
+	"fmt"
+	"mod.com/lib"
+)
+
+const _ = true
+func main() {
+	fmt.Println(lib.Add__0(100, 7))
+	fmt.Println(lib.Add__1("Hello", "World"))
+}
+`
+
+// Test cross package 's overload definition
+func TestOverloadCrossPkg(t *testing.T) {
+	testCases := []match{
+		{`main.gop`, `println lib.(Add)\(100, 7\)`, "lib/lib.gop", `func\(a, b int\) int`},
+		{`main.gop`, `println lib.(Add)\("Hello", "World"\)`, "lib/lib.gop", `func\(a, b string\) string`},
+	}
+	runGoToDefinitionTest(t, overloadCrossPkg, testCases)
+}
+
+type match struct {
+	findLocFile string
+	findLocReg  string
+	wantFile    string
+	wantLocReg  string
+}
+
+func runGoToDefinitionTest(t *testing.T, files string, testCases []match) {
+	Run(t, files, func(t *testing.T, env *Env) {
+		for _, test := range testCases {
+			env.OpenFile(test.findLocFile)
+			loc := env.GoToDefinition(env.RegexpSearch(test.findLocFile, test.findLocReg))
+			name := env.Sandbox.Workdir.URIToPath(loc.URI)
+			if name != test.wantFile {
+				t.Errorf("GoToDefinition: got file %q, want %q", name, test.wantFile)
+			}
+			if want := env.RegexpSearch(test.wantFile, test.wantLocReg); loc != want {
+				t.Errorf("GoToDefinition: got location %v, want %v", loc, want)
+			}
 		}
 	})
 }

--- a/gopls/internal/regtest/misc/definition_gox_test.go
+++ b/gopls/internal/regtest/misc/definition_gox_test.go
@@ -22,6 +22,7 @@ func add = (
 )
 -- test.gop --
 println add(100, 7)
+println add("Hello", "World")
 -- gop_autogen.go --
 package main
 
@@ -36,12 +37,14 @@ func add__1(a string, b string) string {
 }
 func main() {
 	fmt.Println(add__0(100, 7))
+	fmt.Println(add__1("Hello", "World"))
 }
 `
 
 func TestAnonyOverload(t *testing.T) {
-	testCases := []match{
+	testCases := []defTest{
 		{`test.gop`, `println (add)\(100, 7\)`, "def.gop", `func\(a, b int\) int`},
+		{`test.gop`, `println (add)\("Hello", "World"\)`, "def.gop", `func\(a, b string\) string`},
 	}
 	runGoToDefinitionTest(t, anonyOverload, testCases)
 }
@@ -69,6 +72,8 @@ func mul = (
 )
 -- test.gop --
 println mul(100, 7)
+println mul("Hello", "World")
+println mul(200.5, 2.3)
 -- gop_autogen.go --
 package main
 
@@ -87,12 +92,16 @@ func mulFloat(a float64, b float64) float64 {
 }
 func main() {
 	fmt.Println(mulInt(100, 7))
+	fmt.Println(mul__1("Hello", "World"))
+	fmt.Println(mulFloat(200.5, 2.3))
 }
 `
 
 func TestOverloadMixAnonyAndNamed(t *testing.T) {
-	testCases := []match{
+	testCases := []defTest{
 		{`test.gop`, `println (mul)\(100, 7\)`, "def.gop", `func (mulInt)\(a, b int\) int`},
+		{`test.gop`, `println (mul)\("Hello", "World"\)`, "def.gop", `func\(a, b string\) string`},
+		{`test.gop`, `println (mul)\(200.5, 2.3\)`, "def.gop", `func (mulFloat)\(a, b float64\) float64`},
 	}
 	runGoToDefinitionTest(t, overloadMixAnonyAndNamed, testCases)
 }
@@ -121,6 +130,7 @@ func (foo).mul = (
 -- test.gop --
 var a *foo
 var c = a.mul(100)
+var d = a.mul(&foo{})
 -- gop_autogen.go --
 package main
 
@@ -139,14 +149,20 @@ func (a *foo) mulFoo(b *foo) *foo {
 
 var a *foo
 var c = a.mulInt(100)
+var d = a.mulFoo(&foo{})
 
 func main() {
 }
 `
 
 func TestOverloadMethod(t *testing.T) {
-	testCases := []match{
-		{`test.gop`, `var c = a.(mul)\(100\)`, "def.gop", `func \(a \*foo\) (mulInt)\(b int\) \*foo`},
+	mulIntLocReg := `func \(a \*foo\) (mulInt)\(b int\) \*foo`
+	mulFooLocReg := `func \(a \*foo\) (mulFoo)\(b \*foo\) \*foo`
+	testCases := []defTest{
+		{`test.gop`, `var c = a.(mul)\(100\)`, "def.gop", mulIntLocReg},
+		{`test.gop`, `var d = a.(mul)\(&foo\{\}\)`, "def.gop", mulFooLocReg},
+		{`def.gop`, `\(foo\)\.(mulInt)`, "def.gop", mulIntLocReg},
+		{`def.gop`, `\(foo\)\.(mulFoo)`, "def.gop", mulFooLocReg},
 	}
 	runGoToDefinitionTest(t, overloadMethod, testCases)
 }
@@ -181,6 +197,14 @@ n := &N{}
 n.onKey("hello", func() {
 	println("hello world")
 })
+
+n.onKey("hello", func(key string) {
+	println("hello world", key)
+})
+
+n.onKey([]string{"hello", "world"}, func() {
+	println("hello world")
+})
 -- gop_autogen.go --
 package main
 
@@ -192,12 +216,20 @@ func main() {
 	n.OnKey__0("hello", func() {
 		fmt.Println("hello world")
 	})
+	n.OnKey__1("hello", func(key string) {
+		fmt.Println("hello world", key)
+	})
+	n.OnKey__2([]string{"hello", "world"}, func() {
+		fmt.Println("hello world")
+	})
 }
 `
 
 func TestOverloadFromGo(t *testing.T) {
-	testCases := []match{
-		{`test.gop`, `onKey`, "def.go", `OnKey__0`},
+	testCases := []defTest{
+		{`test.gop`, `n.(onKey)\("hello", func\(\)`, "def.go", `OnKey__0`},
+		{`test.gop`, `n.(onKey)\("hello", func\(key string\)`, "def.go", `OnKey__1`},
+		{`test.gop`, `n.(onKey)\(\[\]string\{"hello", "world"\}, func\(\)`, "def.go", `OnKey__2`},
 	}
 	runGoToDefinitionTest(t, overloadFromGo, testCases)
 }
@@ -219,58 +251,187 @@ func Add = (
 	}
 )
 
+func MulInt(a, b int) int {
+	return a * b
+}
+
+func MulFloat(a, b float64) float64 {
+	return a * b
+}
+
+func Mul = (
+	MulInt
+	func(x, y string) string {
+		return x + y
+	}
+	MulFloat
+)
+
+type Foo struct {
+}
+
+func (a *Foo) MulInt(b int) *Foo {
+	return a
+}
+
+func (a *Foo) MulFoo(b *Foo) *Foo {
+	return a
+}
+
+func (Foo).Mul = (
+	(Foo).MulInt
+	(Foo).MulFoo
+)
 -- lib/gop_autogen.go --
 package lib
 
 const GopPackage = true
 const _ = true
+const Gopo_Mul = "MulInt,,MulFloat"
+
+type Foo struct {
+}
+
+const Gopo_Foo_Mul = ".MulInt,.MulFoo"
 func Add__0(a int, b int) int {
 	return a + b
 }
 func Add__1(a string, b string) string {
 	return a + b
 }
+func MulInt(a int, b int) int {
+	return a * b
+}
+func Mul__1(x string, y string) string {
+	return x + y
+}
+func MulFloat(a float64, b float64) float64 {
+	return a * b
+}
+func (a *Foo) MulInt(b int) *Foo {
+	return a
+}
+func (a *Foo) MulFoo(b *Foo) *Foo {
+	return a
+}
+-- lib2/lib2.go --
+package lib2
 
+const GopPackage = true
+
+type N struct {
+}
+
+func (m *N) OnKey__0(a string, fn func()) {
+	fn()
+}
+
+func (m *N) OnKey__1(a string, fn func(key string)) {
+	fn(a)
+}
+
+func (m *N) OnKey__2(a []string, fn func()) {
+	fn()
+}
 -- main.gop --
 import (
 	"mod.com/lib"
+	"mod.com/lib2"
 )
 
 println lib.Add(100, 7)
 println lib.Add("Hello", "World")
 
+println lib.Mul(100, 7)
+println lib.Mul("Hello", "World")
+println lib.Mul(200.5, 2.3)
+
+var a *lib.Foo
+var c = a.Mul(100)
+var d = a.Mul(&lib.Foo{})
+
+_ = c
+_ = d
+
+n := &lib2.N{}
+
+n.OnKey("hello", func() {
+	println("hello world")
+})
+
+n.OnKey("hello", func(key string) {
+	println("hello world", key)
+})
+
+n.OnKey([]string{"hello", "world"}, func() {
+	println("hello world")
+})
 -- gop_autogen.go --
 package main
 
 import (
 	"fmt"
 	"mod.com/lib"
+	"mod.com/lib2"
 )
 
 const _ = true
 func main() {
 	fmt.Println(lib.Add__0(100, 7))
 	fmt.Println(lib.Add__1("Hello", "World"))
+	fmt.Println(lib.MulInt(100, 7))
+	fmt.Println(lib.Mul__1("Hello", "World"))
+	fmt.Println(lib.MulFloat(200.5, 2.3))
+	var a *lib.Foo
+	var c = a.MulInt(100)
+	var d = a.MulFoo(&lib.Foo{})
+	_ = c
+	_ = d
+	n := &lib2.N{}
+	n.OnKey__0("hello", func() {
+		fmt.Println("hello world")
+	})
+	n.OnKey__1("hello", func(key string) {
+		fmt.Println("hello world", key)
+	})
+	n.OnKey__2([]string{"hello", "world"}, func() {
+		fmt.Println("hello world")
+	})
 }
 `
 
 // Test cross package 's overload definition
 func TestOverloadCrossPkg(t *testing.T) {
-	testCases := []match{
+	testCases := []defTest{
+		// anony overload
 		{`main.gop`, `println lib.(Add)\(100, 7\)`, "lib/lib.gop", `func\(a, b int\) int`},
 		{`main.gop`, `println lib.(Add)\("Hello", "World"\)`, "lib/lib.gop", `func\(a, b string\) string`},
+
+		// named & anony overload
+		{`main.gop`, `println lib.(Mul)\(100, 7\)`, "lib/lib.gop", `func (MulInt)\(a, b int\) int`},
+		{`main.gop`, `println lib.(Mul)\("Hello", "World"\)`, "lib/lib.gop", `func\(x, y string\) string`},
+		{`main.gop`, `println lib.(Mul)\(200.5, 2.3\)`, "lib/lib.gop", `func (MulFloat)\(a, b float64\) float64`},
+
+		// method
+		{`main.gop`, `var c = a.(Mul)\(100\)`, "lib/lib.gop", `func \(a \*Foo\) (MulInt)\(b int\) \*Foo`},
+		{`main.gop`, `var d = a.(Mul)\(&lib\.Foo\{\}\)`, "lib/lib.gop", `func \(a \*Foo\) (MulFoo)\(b \*Foo\) \*Foo`},
+
+		// from go
+		{`main.gop`, `n.(OnKey)\("hello", func\(\)`, "lib2/lib2.go", `OnKey__0`},
+		{`main.gop`, `n.(OnKey)\("hello", func\(key string\)`, "lib2/lib2.go", `OnKey__1`},
+		{`main.gop`, `n.(OnKey)\(\[\]string\{"hello", "world"\}, func\(\)`, "lib2/lib2.go", `OnKey__2`},
 	}
 	runGoToDefinitionTest(t, overloadCrossPkg, testCases)
 }
 
-type match struct {
+type defTest struct {
 	findLocFile string
 	findLocReg  string
 	wantFile    string
 	wantLocReg  string
 }
 
-func runGoToDefinitionTest(t *testing.T, files string, testCases []match) {
+func runGoToDefinitionTest(t *testing.T, files string, testCases []defTest) {
 	Run(t, files, func(t *testing.T, env *Env) {
 		for _, test := range testCases {
 			env.OpenFile(test.findLocFile)
@@ -280,7 +441,7 @@ func runGoToDefinitionTest(t *testing.T, files string, testCases []match) {
 				t.Errorf("GoToDefinition: got file %q, want %q", name, test.wantFile)
 			}
 			if want := env.RegexpSearch(test.wantFile, test.wantLocReg); loc != want {
-				t.Errorf("GoToDefinition: got location %v, want %v", loc, want)
+				t.Errorf("GoToDefinition:%v got location %v, want %v", test.findLocReg, loc, want)
 			}
 		}
 	})


### PR DESCRIPTION
support correct anonymous overloaded function definition location
* same package
* different package
-----
fix #262 
<img width="365" alt="image" src="https://github.com/goplus/tools/assets/51194195/9ea90ffe-e1b0-4a64-a6fa-15d6fbf0ca1b">

<img width="443" alt="image" src="https://github.com/goplus/tools/assets/51194195/fbbd9627-72d2-4832-b62d-d21f43728cc1">




