### PR TITLE
fix:unexpected gop overload completion in go

### DIFF
--- a/gopls/internal/lsp/source/completion/deep_completion.go
+++ b/gopls/internal/lsp/source/completion/deep_completion.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/goplus/gogen"
 	"github.com/qiniu/x/log"
 	"golang.org/x/tools/gopls/internal/goxls"
 )
@@ -138,7 +139,11 @@ func (c *completer) deepSearch(ctx context.Context, start time.Time, deadline *t
 			if obj == nil {
 				continue
 			}
-
+			if sig, ok := obj.Type().(*types.Signature); ok { //goxls:skip gop overload
+				if _, ok := gogen.CheckSigFuncEx(sig); ok {
+					continue
+				}
+			}
 			// At the top level, dedupe by object.
 			if len(cand.path) == 0 {
 				if c.seen[obj] {


### PR DESCRIPTION
#277 
**Temporary solution (temporary only):** 
ignore the overloaded function declaration of go+ during the candidate collection of go's completion

<img width="453" alt="image" src="https://github.com/goplus/tools/assets/51194195/af55f3f4-2441-43cc-bf47-d43158dc9d65">
